### PR TITLE
feat: add max width to md-grid

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -12,7 +12,7 @@
 }
 
 .md-grid {
-    max-width: initial;
+    max-width: 80rem;
 }
 
 html {


### PR DESCRIPTION
Adds a max-width to md-grid of `80rem` to ensure that content isn't absurdly long on larger screens. Has the added benefit of making the content centered on normal screens without affecting the collapsed sidebar state.

Before (huge screen): 

![image](https://user-images.githubusercontent.com/502396/129496521-3220a589-9f93-4331-a952-8bcf580203bd.png)

After (huge screen):

![image](https://user-images.githubusercontent.com/502396/129496513-f358ef57-53e0-4fdf-9de4-b41b96981cfe.png)

Before (normal screen): 

![image](https://user-images.githubusercontent.com/502396/129496540-a7e95dd4-eed1-4ce7-8ea7-cd0b71b24bd7.png)

After (normal screen):

![image](https://user-images.githubusercontent.com/502396/129496533-ad49f5e5-649d-4ff0-a330-c6191274eb56.png)
