### PR TITLE
custom rule formatting now disabled for inline code

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -4,6 +4,9 @@ Updates for the website.
 
 For bugs or feature requests, message me on Discord (Pleb#0025) or create an issue on [Github](https://github.com/pvme/pvme.github.io).
 
+## April 16, 2023
+- Urls and other formatting now disabled when text is in `inline code field`
+
 ## April 6, 2023
 
 - Added "Editor Info" and "Mastery" categories

--- a/site_builder/formatter/message_formatter.py
+++ b/site_builder/formatter/message_formatter.py
@@ -91,13 +91,20 @@ class MessageFormatter:
             if index % 2 == 0:
                 # section should be formatted (not in code block)
                 content = self.set_code_block_margin(sections_split_by_code_block, index)
-
-                content, attachment_embeds = self.apply_formatting_rules(content, format_sequence)
-                self.__formatted_message.content += content
-                self.__formatted_message.attachment_embeds.extend(attachment_embeds)
+                self.__format_non_code_block_section(content, format_sequence)
             else:
                 # section inside code block, don't apply formatting
                 self.__formatted_message.content += self.set_code_block_padding(section)
+
+    def __format_non_code_block_section(self, content, format_sequence):
+        sections_split_by_inline_code = self.split_inline_code_sections(content)
+        for index, section in enumerate(sections_split_by_inline_code):
+            if index % 2 == 0:
+                content, attachment_embeds = self.apply_formatting_rules(section, format_sequence)
+                self.__formatted_message.content += content
+                self.__formatted_message.attachment_embeds.extend(attachment_embeds)
+            else:
+                self.__formatted_message.content += f"`{section}`"
 
     def format(self, format_sequence: List = None):
         format_sequence = format_sequence if format_sequence else DEFAULT_FORMAT_SEQUENCE
@@ -139,6 +146,10 @@ class MessageFormatter:
     @staticmethod
     def split_code_block_sections(content: str) -> List[str]:
         return content.split('```')
+
+    @staticmethod
+    def split_inline_code_sections(content: str) -> List[str]:
+        return content.split('`')
 
     @staticmethod
     def set_code_block_margin(sections: List[str], non_code_section_index: int) -> str:


### PR DESCRIPTION
small side effect of adding empty characters but has no effect on end formatting 
![image](https://user-images.githubusercontent.com/73656340/232334282-432ecac5-d4c9-43b7-98e2-9fff1fa42f67.png)
